### PR TITLE
Add a mechanism to silence the warning about the presence of FS.h

### DIFF
--- a/src/SdFat.h
+++ b/src/SdFat.h
@@ -445,7 +445,9 @@ typedef FsBaseFile SdBaseFile;
 #if defined __has_include
 #if __has_include(<FS.h>)
 #define HAS_INCLUDE_FS_H
+#ifndef SDFAT_NO_FS_H_WARNING
 #warning File not defined because __has_include(FS.h)
+#endif  // !defined SDFAT_NO_FS_WARNING
 #endif  // __has_include(<FS.h>)
 #endif  // defined __has_include
 #ifndef HAS_INCLUDE_FS_H


### PR DESCRIPTION
This is a functionnal no-op. When the new SDFAT_NO_FS_H_WARNING define is set the warning about the presence of FS.h is suppressed but the behavior of the code is not changed.